### PR TITLE
1580 fix: Removed additional added line

### DIFF
--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -135,16 +135,10 @@ namespace Terminal.Gui {
 		public override string ToString ()
 		{
 			var sb = new StringBuilder ();
-			bool first = true;
 			for (int i = 0; i < lines.Count; i++) {
-				if (first)
-					first = false;
-				else
+				if (i > 0)
 					sb.AppendLine ();
 				sb.Append (ustring.Make (lines [i]));
-				if ((i + 1) < lines.Count) {
-					sb.AppendLine ();
-				}
 			}
 			return sb.ToString ();
 		}


### PR DESCRIPTION
Fixed the issue by removing duplicated newline-related logic for ToString on TextModel.